### PR TITLE
Fix for error when last data event completes after the boundary.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Created by .ignore support plugin (hsz.mobi)
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-# Created by .ignore support plugin (hsz.mobi)
 .idea/
+.npmrc
+node_modules/

--- a/package.json
+++ b/package.json
@@ -18,5 +18,10 @@
     "evented"
   ],
   "author": "Tristan Slominski <tristan.slominski@gmail.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "mocha": "^3.2.0",
+    "sinon": "^2.1.0"
+  }
 }

--- a/precommit.sh
+++ b/precommit.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+node_modules/mocha/bin/mocha "test/**/*.test.js"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,68 @@
+const chai = require('chai');
+const expect = chai.expect;
+const multipartser = require('../index');
+const sinon = require('sinon');
+
+describe('multipartser', () => {
+  const boundary = 'boundary';
+  let emitter;
+  let partsStub;
+
+  beforeEach(() => {
+    emitter = multipartser();
+    emitter.boundary(boundary);
+    partsStub = sinon.stub();
+    emitter.on('parts', partsStub);
+  });
+
+  it('parses simple case into parts', () => {
+    const dataBlock1 =
+      `\r\n--${boundary}\r\nvery very interesting data` +
+      `\r\n--${boundary}--\r\n`;
+
+    emitter.data(dataBlock1);
+    emitter.end();
+    expect(partsStub.firstCall.args[0]).to.eql(['\r\nvery very interesting data\r\n']);
+  });
+
+  it('parses multiparts into parts', () => {
+    const dataBlock1 =
+      `\r\n--${boundary}\r\nvery very interesting data` +
+      `\r\n--${boundary}\r\nnot very interesting data` +
+      `\r\n--${boundary}--\r\n`;
+
+    emitter.data(dataBlock1);
+    emitter.end();
+    const expectedParts = [
+      '\r\nvery very interesting data\r\n',
+      '\r\nnot very interesting data\r\n',
+    ];
+    expect(partsStub.firstCall.args[0]).to.eql(expectedParts);
+  });
+
+  it('parses multiple data events into parts', () => {
+    const dataBlock1 =
+      `\r\n--${boundary}\r\nvery very interesting data` +
+      `\r\n--${boundary}\r\nnot very`;
+    const dataBlock2 = ` interesting data\r\n--${boundary}--\r\n`;
+
+    emitter.data(dataBlock1);
+    emitter.data(dataBlock2);
+    emitter.end();
+
+    expect(partsStub.firstCall.args[0]).to.eql(['\r\nvery very interesting data\r\n']);
+    expect(partsStub.secondCall.args[0]).to.eql(['\r\nnot very interesting data\r\n']);
+  });
+
+  it('parses multiple data events into parts when last data event completes the boundary', () => {
+    const dataBlock1 =
+      `\r\n--${boundary}\r\nvery very interesting data` +
+      `\r\n--${boundary}-`;
+    const dataBlock2 = `-\r\n`;
+
+    emitter.data(dataBlock1);
+    emitter.data(dataBlock2);
+    emitter.end();
+    expect(partsStub.firstCall.args[0]).to.eql(['\r\nvery very interesting data\r\n']);
+  })
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -54,7 +54,7 @@ describe('multipartser', () => {
     expect(partsStub.secondCall.args[0]).to.eql(['\r\nnot very interesting data\r\n']);
   });
 
-  it('parses multiple data events into parts when last data event completes the boundary', () => {
+  it('parses multiple data events into parts when last data event completes after the boundary', () => {
     const dataBlock1 =
       `\r\n--${boundary}\r\nvery very interesting data` +
       `\r\n--${boundary}-`;
@@ -64,5 +64,17 @@ describe('multipartser', () => {
     emitter.data(dataBlock2);
     emitter.end();
     expect(partsStub.firstCall.args[0]).to.eql(['\r\nvery very interesting data\r\n']);
-  })
+  });
+
+  it('parses multiple data events into parts when last data event completes the boundary', () => {
+    const dataBlock1 =
+      `\r\n--${boundary}\r\nvery very interesting data` +
+      `\r\n--bound`;
+    const dataBlock2 = `ary--\r\n`;
+
+    emitter.data(dataBlock1);
+    emitter.data(dataBlock2);
+    emitter.end();
+    expect(partsStub.firstCall.args[0]).to.eql(['\r\nvery very interesting data\r\n']);
+  });
 });


### PR DESCRIPTION
I was getting an error when the last data event in a stream was just a '-'. The best way to understand the issue is to look at the failing mocha test when pointing to commit 631dcc8. The fix comes in the subsequent commit.